### PR TITLE
docs/swagger: add Swagger documentation for all API routes

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -1,17 +1,20 @@
 import express from "express";
+import swagger from "./swagger.mjs";
 import questionRouter from "./routes/questionsRoutes.mjs";
 import answersRouter from "./routes/answersRoutes.mjs";
 import voteAnswerRouter from "./routes/voteAnswerRoutes.mjs";
+
 
 const app = express();
 const port = 4000;
 
 app.use(express.json());
 
+// Swagger route
+app.use('/api-docs', swagger.swaggerUi.serve, swagger.swaggerUi.setup(swagger.swaggerSpec));
+
 app.use("/questions", questionRouter);
-
 app.use("/questions/:questionId/answers", answersRouter);
-
 app.use("/answers/:answerId/vote", voteAnswerRouter);
 
 app.get("/test", (req, res) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,73 @@
       "dependencies": {
         "express": "^4.21.2",
         "nodemon": "^3.1.9",
-        "pg": "^8.14.1"
+        "pg": "^8.14.1",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -37,6 +102,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
@@ -141,6 +212,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -162,6 +239,15 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/concat-map": {
@@ -231,6 +317,18 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -295,6 +393,15 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/etag": {
       "version": "1.8.1",
@@ -397,6 +504,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -454,6 +567,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -544,6 +678,17 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -595,6 +740,38 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -768,6 +945,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -775,6 +968,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1197,6 +1399,62 @@
         "node": ">=4"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1260,6 +1518,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.0.tgz",
+      "integrity": "sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1268,6 +1535,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -1275,6 +1548,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "express": "^4.21.2",
     "nodemon": "^3.1.9",
-    "pg": "^8.14.1"
+    "pg": "^8.14.1",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
   },
   "repository": {
     "type": "git",

--- a/routes/answersRoutes.mjs
+++ b/routes/answersRoutes.mjs
@@ -4,6 +4,62 @@ import answerValidate from "../middlewares/answerValidate.mjs";
 
 const answersRouter = express.Router({ mergeParams: true });
 
+/**
+ * @swagger
+ * /questions/{questionId}/answers:
+ *   get:
+ *     summary: Get answers for a specific question
+ *     description: Retrieves all answers associated with a given question ID. Returns an empty array if there are no answers.
+ *     tags:
+ *       - Answers
+ *     parameters:
+ *       - in: path
+ *         name: questionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The unique ID of the question to fetch answers for.
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved answers for the question.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                         example: "123"
+ *                       content:
+ *                         type: string
+ *                         example: "This is an answer."
+ *                   example: []  # could be an empty list
+ *       404:
+ *         description: Question not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Question not found.
+ *       500:
+ *         description: Server error while fetching answers.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Unable to fetch answers.
+ */
 answersRouter.get("/", async (req, res) => {
   const questionIdFromClient = req.params.questionId;
 
@@ -26,10 +82,6 @@ answersRouter.get("/", async (req, res) => {
       [questionIdFromClient]
     );
 
-    if (response.rowCount === 0) {
-      return res.status(404).json({ message: "Answers not found." });
-    }
-
     return res.status(200).json({ data: response.rows });
   } catch (error) {
     console.error("Error found: ", error);
@@ -37,6 +89,76 @@ answersRouter.get("/", async (req, res) => {
   }
 });
 
+/**
+ * @swagger
+ * /questions/{questionId}/answers:
+ *   post:
+ *     summary: Create an answer for a specific question
+ *     description: Adds a new answer to the question identified by questionId.
+ *     tags:
+ *       - Answers
+ *     parameters:
+ *       - in: path
+ *         name: questionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The unique ID of the question to answer.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - content
+ *             properties:
+ *               content:
+ *                 type: string
+ *                 example: "Here is a detailed answer to your question."
+ *                 description: The content of the answer.
+ *     responses:
+ *       201:
+ *         description: Answer created successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Answer created successfully.
+ *       400:
+ *         description: Answer was not created due to bad input or other issue.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Answer was not created.
+ *       404:
+ *         description: Question not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Question not found.
+ *       500:
+ *         description: Server error while creating the answer.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Unable to create answer.
+ */
 answersRouter.post("/", [answerValidate],async (req, res) => {
   const questionIdFromClient = req.params.questionId;
   const {content} = req.body;
@@ -70,10 +192,57 @@ answersRouter.post("/", [answerValidate],async (req, res) => {
       }
   } catch (error) {
     console.error("Error found: ", error);
-    return res.status(500).json({ message: "Unable to fetch answers." });
+    return res.status(500).json({ message: "Unable to create answer." });
   }
 });
 
+/**
+ * @swagger
+ * /questions/{questionId}/answers:
+ *   delete:
+ *     summary: Delete all answers for a specific question
+ *     description: Deletes all answers associated with a given question ID. If there are no answers to delete, returns a 200 OK with a message.
+ *     tags:
+ *       - Answers
+ *     parameters:
+ *       - in: path
+ *         name: questionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The unique ID of the question whose answers will be deleted.
+ *     responses:
+ *       200:
+ *         description: Deletion request processed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: All answers for the question have been deleted successfully.
+ *       404:
+ *         description: Question not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Question not found.
+ *       500:
+ *         description: Server error occurred while deleting answers.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Unable to delete answers.
+ */
 answersRouter.delete("/", async (req, res) => {
     const questionIdFromClient = req.params.questionId;
 
@@ -93,15 +262,12 @@ answersRouter.delete("/", async (req, res) => {
         `delete from answers where question_id = $1`, 
         [questionIdFromClient])
 
-        if (response.rowCount > 0) {
-            return res.status(200).json({
-              "message": "All answers for the question have been deleted successfully.",
-            });
-          } else {
-            return res.status(400).json({
-              "message": "Answers were not daleted.",
-            });
-          }
+        return res.status(200).json({
+          message:
+            response.rowCount > 0
+              ? "All answers for the question have been deleted successfully."
+              : "No answers were found to delete.",
+        });        
     } catch(error) {
         console.error("Error found: ", error);
         return res.status(500).json({"message": "Unable to delete answers."})

--- a/routes/questionsRoutes.mjs
+++ b/routes/questionsRoutes.mjs
@@ -4,9 +4,26 @@ import questionValidate from "../middlewares/questionValidate.mjs";
 import searchQueryValidate from "../middlewares/searchQueryValidate.mjs";
 import voteValidate from "../middlewares/voteValidate.mjs";
 
-
 const questionRouter = express.Router();
 
+/**
+ * @swagger
+ * /questions:
+ *   get:
+ *     summary: Get all questions
+ *     tags: [Questions]
+ *     responses:
+ *       200:
+ *         description: A list of questions
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *       500:
+ *         description: Unable to fetch a question
+ */
 questionRouter.get("/", async (req, res) => {
   try {
     const response = await connectionPool.query(`select * from questions`);
@@ -14,12 +31,46 @@ questionRouter.get("/", async (req, res) => {
     return res.status(200).json({ data: response.rows });
   } catch (error) {
     console.error("Error found: ", error);
-    return res.status(500).json({ "message": "Unable to fetch questions." });
+    return res.status(500).json({ message: "Unable to fetch questions." });
   }
 });
 
+/**
+ * @swagger
+ * /questions/search:
+ *   get:
+ *     summary: Search questions by title or category
+ *     tags: [Questions]
+ *     parameters:
+ *       - in: query
+ *         name: title
+ *         schema:
+ *           type: string
+ *         description: Keyword to match the question title
+ *       - in: query
+ *         name: category
+ *         schema:
+ *           type: string
+ *         description: Keyword to match the question category
+ *     responses:
+ *       200:
+ *         description: A list of questions
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *       400:
+ *        description: Invalid search parameters
+ *       404:
+ *        description: Question not found
+ *       500:
+ *        description: Unable to fetch a question
+ *
+ */
 questionRouter.get("/search", [searchQueryValidate], async (req, res) => {
-  const {title, category} = req.query;
+  const { title, category } = req.query;
 
   try {
     let conditions = [];
@@ -38,14 +89,15 @@ questionRouter.get("/search", [searchQueryValidate], async (req, res) => {
       count++;
     }
 
-    const whereClause = conditions.length > 0? `WHERE ${conditions.join(" AND ")}` : "";
+    const whereClause =
+      conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-    const query = `SELECT * FROM questions ${whereClause} ORDER BY id ASC`
+    const query = `SELECT * FROM questions ${whereClause} ORDER BY id ASC`;
 
     const response = await connectionPool.query(query, values);
 
     if (response.rowCount === 0) {
-      return res.status(404).json({ "message": "Question not found." });
+      return res.status(404).json({ message: "Question not found." });
     }
 
     return res.status(200).json({
@@ -53,10 +105,40 @@ questionRouter.get("/search", [searchQueryValidate], async (req, res) => {
     });
   } catch (error) {
     console.error("Error found: ", error);
-    return res.status(500).json({ "message": "Unable to fetch questions." });
+    return res.status(500).json({ message: "Unable to fetch questions." });
   }
 });
 
+/**
+ * @swagger
+ * /questions/{questionId}:
+ *   get:
+ *     summary: Get a specific question by ID
+ *     tags: [Questions]
+ *     parameters:
+ *       - in: path
+ *         name: questionId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID of the question to retrieve
+ *     responses:
+ *       200:
+ *         description: The requested question
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *       404:
+ *         description: Question not found
+ *       500:
+ *         description: Unable to fetch questions
+ */
 questionRouter.get("/:questionId", async (req, res) => {
   const questionIdFromClient = req.params.questionId;
   try {
@@ -66,7 +148,7 @@ questionRouter.get("/:questionId", async (req, res) => {
     );
 
     if (response.rowCount === 0) {
-      return res.status(404).json({ "message": "Question not found." });
+      return res.status(404).json({ message: "Question not found." });
     }
 
     return res.status(200).json({
@@ -74,10 +156,38 @@ questionRouter.get("/:questionId", async (req, res) => {
     });
   } catch (error) {
     console.error("Error found: ", error);
-    return res.status(500).json({ "message": "Unable to fetch questions." });
+    return res.status(500).json({ message: "Unable to fetch questions." });
   }
 });
 
+/**
+ * @swagger
+ * /questions:
+ *   post:
+ *     summary: Create a new question
+ *     tags: [Questions]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               category:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Question created successfully
+ *       400:
+ *        description: Invalid request data
+ *       500:
+ *        description: Unable to fetch a question
+ *
+ */
 questionRouter.post("/", [questionValidate], async (req, res) => {
   const { title, description, category } = req.body;
 
@@ -90,91 +200,260 @@ questionRouter.post("/", [questionValidate], async (req, res) => {
 
     if (response.rowCount === 1) {
       return res.status(201).json({
-        "message": "Question created successfully.",
+        message: "Question created successfully.",
       });
     } else {
       return res.status(400).json({
-        "message": "Question was not created.",
+        message: "Question was not created.",
       });
     }
   } catch (error) {
     console.error("Error found: ", error);
-    return res.status(500).json({ "message": "Unable to create question." });
+    return res.status(500).json({ message: "Unable to create question." });
   }
 });
 
+/**
+ * @swagger
+ * /questions/{questionId}:
+ *   put:
+ *     summary: Update an existing question
+ *     tags: [Questions]
+ *     parameters:
+ *       - in: path
+ *         name: questionId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: ID of the question to update
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - title
+ *               - description
+ *               - category
+ *             properties:
+ *               title:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               category:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Question updated successfully
+ *       400:
+ *         description: Question was not updated
+ *       404:
+ *         description: Question not found
+ *       500:
+ *         description: Unable to fetch questions
+ */
 questionRouter.put("/:questionId", [questionValidate], async (req, res) => {
   const { title, description, category } = req.body;
   const questionIdFromClient = req.params.questionId;
 
   try {
     const response = await connectionPool.query(
-    `UPDATE questions 
+      `UPDATE questions 
     SET title = $1, description = $2, category = $3
     WHERE id = $4`,
       [title, description, category, questionIdFromClient]
     );
 
     if (response.rowCount === 0) {
-      return res.status(404).json({ "message": "Question not found." });
+      return res.status(404).json({ message: "Question not found." });
     }
 
     if (response.rowCount === 1) {
       return res.status(200).json({
-        "message": "Question updated successfully.",
+        message: "Question updated successfully.",
       });
     } else {
       return res.status(400).json({
-        "message": "Question was not updated.",
+        message: "Question was not updated.",
       });
     }
   } catch (error) {
     console.error("Error found: ", error);
-    return res.status(500).json({ "message": "Unable to fetch questions." });
+    return res.status(500).json({ message: "Unable to fetch questions." });
   }
 });
 
+/**
+ * @swagger
+ * /questions/{questionId}:
+ *   delete:
+ *     summary: Delete a question by ID
+ *     description: Deletes a question post from the database using the provided question ID.
+ *     tags:
+ *       - Questions
+ *     parameters:
+ *       - in: path
+ *         name: questionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The unique ID of the question to be deleted.
+ *     responses:
+ *       200:
+ *         description: Question post has been deleted successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Question post has been deleted successfully.
+ *       404:
+ *         description: Question not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Question not found.
+ *       400:
+ *         description: Question was not deleted due to an unexpected issue.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Question was not deleted.
+ *       500:
+ *         description: Server error occurred while deleting the question.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Unable to delete question.
+ */
 questionRouter.delete("/:questionId", async (req, res) => {
   const questionIdFromClient = req.params.questionId;
 
   try {
     const response = await connectionPool.query(
-    `DELETE FROM questions
+      `DELETE FROM questions
     WHERE id = $1`,
       [questionIdFromClient]
     );
 
     if (response.rowCount === 0) {
-      return res.status(404).json({ "message": "Question not found." });
+      return res.status(404).json({ message: "Question not found." });
     }
 
     if (response.rowCount === 1) {
       return res.status(200).json({
-        "message": "Question post has been deleted successfully.",
+        message: "Question post has been deleted successfully.",
       });
     } else {
       return res.status(400).json({
-        "message": "Question was not daleted.",
+        message: "Question was not daleted.",
       });
     }
   } catch (error) {
     console.error("Error found: ", error);
-    return res.status(500).json({"message": "Unable to delete question."});
+    return res.status(500).json({ message: "Unable to delete question." });
   }
 });
 
+/**
+ * @swagger
+ * /questions/{questionId}/vote:
+ *   post:
+ *     summary: Vote on a question
+ *     description: Records a vote (e.g., upvote/downvote) on a specific question by its ID.
+ *     tags:
+ *       - Questions
+ *     parameters:
+ *       - in: path
+ *         name: questionId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The unique ID of the question to vote on.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - vote
+ *             properties:
+ *               vote:
+ *                 type: integer
+ *                 example: 1
+ *                 description: Vote value (e.g., 1 for upvote, -1 for downvote).
+ *     responses:
+ *       201:
+ *         description: Vote on the question has been recorded successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Vote on the question has been recorded successfully.
+ *       404:
+ *         description: Question not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Question not found.
+ *       400:
+ *         description: Vote could not be recorded due to a bad request.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Vote on the question cannot be recorded.
+ *       500:
+ *         description: Server error occurred while creating the vote.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Unable to create question.
+ */
 questionRouter.post("/:questionId/vote", [voteValidate], async (req, res) => {
   const questionIdFromClient = req.params.questionId;
   const { vote } = req.body;
 
   try {
     // Check if question exists
-    const checkQuestion = await connectionPool.query(`
+    const checkQuestion = await connectionPool.query(
+      `
       select * from questions
       where id = $1`,
-    [questionIdFromClient])
+      [questionIdFromClient]
+    );
 
-    if(checkQuestion.rowCount === 0){
+    if (checkQuestion.rowCount === 0) {
       return res.status(404).json({ message: "Question not found." });
     }
 
@@ -187,16 +466,16 @@ questionRouter.post("/:questionId/vote", [voteValidate], async (req, res) => {
 
     if (response.rowCount === 1) {
       return res.status(201).json({
-         "message": "Vote on the question has been recorded successfully."
+        message: "Vote on the question has been recorded successfully.",
       });
     } else {
       return res.status(400).json({
-        "message": "Vote on the question cannot be recorded."
+        message: "Vote on the question cannot be recorded.",
       });
     }
   } catch (error) {
     console.error("Error found: ", error);
-    return res.status(500).json({ "message": "Unable to create question." });
+    return res.status(500).json({ message: "Unable to create question." });
   }
 });
 

--- a/routes/voteAnswerRoutes.mjs
+++ b/routes/voteAnswerRoutes.mjs
@@ -4,6 +4,76 @@ import voteValidate from "../middlewares/voteValidate.mjs";
 
 const voteAnswerRouter = express.Router({ mergeParams: true });
 
+/**
+ * @swagger
+ * /answers/{answerId}/vote:
+ *   post:
+ *     summary: Vote on an answer
+ *     description: Records a vote (e.g., upvote or downvote) on a specific answer by its ID.
+ *     tags:
+ *       - Answers
+ *     parameters:
+ *       - in: path
+ *         name: answerId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The unique ID of the answer to vote on.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - vote
+ *             properties:
+ *               vote:
+ *                 type: integer
+ *                 example: 1
+ *                 description: Vote value (e.g., 1 for upvote, -1 for downvote).
+ *     responses:
+ *       200:
+ *         description: Vote on the answer has been recorded successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Vote on the answer has been recorded successfully.
+ *       404:
+ *         description: Answer not found.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Question not found.
+ *       400:
+ *         description: Vote could not be recorded due to a bad request.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Vote on the answer can not record.
+ *       500:
+ *         description: Server error occurred while voting on the answer.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Unable to vote answer.
+ */
 voteAnswerRouter.post("/", [voteValidate],async (req, res) => {
   const answerIdFromClient = req.params.answerId;
   const { vote } = req.body;

--- a/swagger.mjs
+++ b/swagger.mjs
@@ -1,0 +1,19 @@
+// swagger.js
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+
+const options = {
+  definition: {
+    openapi: '3.0.0', // OpenAPI version
+    info: {
+      title: 'Q&A API',
+      version: '1.0.0',
+      description: 'API docs for questions, answers and voting system',
+    },
+  },
+  apis: ['./routes/questionsRoutes.mjs', './routes/answersRoutes.mjs', './routes/voteAnswerRoutes.mjs'], // location of route files
+};
+
+const swaggerSpec = swaggerJsdoc(options);
+
+export default { swaggerUi, swaggerSpec };


### PR DESCRIPTION
This pull request adds comprehensive Swagger (OpenAPI) documentation for all existing API routes. The documentation includes:

- Endpoint summaries and descriptions
- Path parameters and their schemas
- Expected responses with example messages
- Categorization using tags for better organization